### PR TITLE
Feat/transfer pause

### DIFF
--- a/contract/contracts/artifaqt/Artifaqt.sol
+++ b/contract/contracts/artifaqt/Artifaqt.sol
@@ -7,7 +7,7 @@ contract Artifaqt is EIP721 {
     address public admin;
 
     // Bool to pause transfers
-    bool transferPaused = true;
+    bool transferResumed = false;
 
     // Array holding the sin hashes
     bytes32[] private sins;
@@ -168,27 +168,14 @@ contract Artifaqt is EIP721 {
         super.transferFrom(_from, _to, _tokenId);
     }
 
-    /// @notice Change or reaffirm the approved address for an NFT.
-    /// @dev Calls the parent function if transfers are not paused
-    /// @param _approved The new approved NFT controller
-    /// @param _tokenId The NFT to approve
-    function approve(
-        address _approved, 
-        uint256 _tokenId
-    ) public payable transferAllowed {
-        super.approve(_approved, _tokenId);
-    }
-
-    /// @notice Enable or disable approval for a third party ("operator") to manage
-    ///  all of `msg.sender`'s assets.
-    /// @dev Calls the parent function if transfers are not paused
-    /// @param _operator Address to add to the set of authorized operators.
-    /// @param _approved True if the operator is approved, false to revoke approval
-    function setApprovalForAll(
-        address _operator, 
-        bool _approved
-    ) public transferAllowed {    
-        super.setApprovalForAll(_operator, _approved);
+    /// @notice Enables or disables transfers
+    /// @dev Set to `true` to enable transfers or `false` to disable transfers. 
+    /// If it is set to `false` all functions that transfer tokens are paused and will revert.
+    /// Functions that approve transfers (`approve()` and `setTransferForAll()`) still work 
+    /// because they do not transfer tokens immediately.
+    /// @param _resume This should be set to `true` if transfers should be enabled, `false` otherwise
+    function allowTransfer(bool _resume) public onlyAdmin {
+        transferResumed = _resume;
     }
 
     /// @notice Returns true of the `_player` has the requested `_tokenType`
@@ -230,7 +217,7 @@ contract Artifaqt is EIP721 {
     }
 
     modifier transferAllowed() {
-        require(transferPaused == false);
+        require(transferResumed);
         _;
     }
 }

--- a/contract/contracts/eip721/EIP721.sol
+++ b/contract/contracts/eip721/EIP721.sol
@@ -127,7 +127,7 @@ contract EIP721 is EIP721Interface, EIP721MetadataInterface, EIP721EnumerableInt
     ///  operator of the current owner.
     /// @param _approved The new approved NFT controller
     /// @param _tokenId The NFT to approve
-    function approve(address _approved, uint256 _tokenId) public payable
+    function approve(address _approved, uint256 _tokenId) external payable
     tokenExists(_tokenId)
     allowedToOperate(_tokenId) {
         address owner = ownerOfToken[_tokenId];
@@ -140,7 +140,7 @@ contract EIP721 is EIP721Interface, EIP721MetadataInterface, EIP721EnumerableInt
     ///  multiple operators per owner.
     /// @param _operator Address to add to the set of authorized operators.
     /// @param _approved True if the operator is approved, false to revoke approval
-    function setApprovalForAll(address _operator, bool _approved) public {
+    function setApprovalForAll(address _operator, bool _approved) external {
         require(_operator != msg.sender); // can't make oneself an operator
         operators[msg.sender][_operator] = _approved;
         emit ApprovalForAll(msg.sender, _operator, _approved);

--- a/contract/contracts/eip721/EIP721Interface.sol
+++ b/contract/contracts/eip721/EIP721Interface.sol
@@ -63,7 +63,7 @@ interface EIP721Interface {
     ///  operator of the current owner.
     /// @param _approved The new approved NFT controller
     /// @param _tokenId The NFT to approve
-    function approve(address _approved, uint256 _tokenId) public payable;
+    function approve(address _approved, uint256 _tokenId) external payable;
 
     /// @notice Enable or disable approval for a third party ("operator") to manage
     ///  all of `msg.sender`'s assets.
@@ -71,7 +71,7 @@ interface EIP721Interface {
     ///  multiple operators per owner.
     /// @param _operator Address to add to the set of authorized operators.
     /// @param _approved True if the operator is approved, false to revoke approval
-    function setApprovalForAll(address _operator, bool _approved) public;
+    function setApprovalForAll(address _operator, bool _approved) external;
 
     /// @notice Get the approved address for a single NFT
     /// @dev Throws if `_tokenId` is not a valid NFT

--- a/contract/test/artifaqt/artifaqt.js
+++ b/contract/test/artifaqt/artifaqt.js
@@ -257,7 +257,7 @@ contract('Artifaqt', async (accounts) => {
         assert.equal(token2Data[2], 1, 'token 2 type not as expected');
     });
 
-    it('transfer: players should not be able to transfer or approve transfers', async () => {
+    it('transfer pause: players should not be able to transfer or approve transfers', async () => {
         // Admin mints token for player
         const token = await artifaqt.mintToken(
             player,
@@ -286,21 +286,36 @@ contract('Artifaqt', async (accounts) => {
             safeTransferFrom,
         );
 
-        // Player should not be able to approve an address
-        await assertRevert(
-            artifaqt.approve(player2, tokenId, { from: player }),
-        );
-
-        // Player should not be able to setApprovalForAll
-        await assertRevert(
-            artifaqt.setApprovalForAll(player2, true, { from: player }),
-        );
-
         // Player still owns the token
         assert.equal(
             await artifaqt.ownerOf(tokenId),
             player,
             'player did not transfer token',
+        );
+    });
+
+    it('transfer pause: admin should be able to resume transfers', async () => {
+        // Admin mints token for player
+        const token = await artifaqt.mintToken(
+            player,
+            0,
+            { from: owner },
+        );
+
+        // Minted token id
+        const tokenId = token.logs[0].args._tokenId.toNumber();
+
+        // Admin resumes transfers
+        await artifaqt.allowTransfer(true, { from: owner });
+
+        // Player is able to sent token
+        await artifaqt.transferFrom(player, player2, tokenId, { from: player });
+
+        // Player2 owns the token
+        assert.equal(
+            await artifaqt.ownerOf(tokenId),
+            player2,
+            'player2 should own the token',
         );
     });
 });


### PR DESCRIPTION
Transfers are disabled by default.
After the party, admin will enable the transfers.

https://trello.com/c/CLM2XRoY/39-token-transfers-should-be-disabled-by-default